### PR TITLE
Fix crash on empty table cell select

### DIFF
--- a/HackerNews/ViewController.m
+++ b/HackerNews/ViewController.m
@@ -482,7 +482,7 @@
 }
 
 -(void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (tableView == frontPageTable) {
+    if (tableView == frontPageTable && indexPath.row < [homePagePosts count]) {
         // Set Current Post
         currentPost = homePagePosts[indexPath.row];
         


### PR DESCRIPTION
This fixes #12 in which the app would crash when the user selected the topmost table cell before articles are loaded at startup. The cause was a missing array bounds check.
